### PR TITLE
feat(android): add pageNumber API

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ win.open();
 - <b>midZoom (float)</b> : sets mid zoom level (default 1.75)
 - <b>maxZoom (float)</b> : sets max zoom level (default 3)
 * <b>nestedScrolling (boolean)</b> : enabled nested srcolling (default: false)
-- <b>pageNumber (int)</b> : sets the initial page number to display (default 0)
+- <b>pageNumber (int)</b> : sets the initial page number to display (default 0). Number is the page index starting with 0 (page 1).
 
 ## Events
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ win.open();
 - <b>midZoom (float)</b> : sets mid zoom level (default 1.75)
 - <b>maxZoom (float)</b> : sets max zoom level (default 3)
 * <b>nestedScrolling (boolean)</b> : enabled nested srcolling (default: false)
+- <b>pageNumber (int)</b> : sets the initial page number to display (default 0)
 
 ## Events
 

--- a/android/src/fr/squirrel/pdfview/PdfViewer.java
+++ b/android/src/fr/squirrel/pdfview/PdfViewer.java
@@ -38,6 +38,7 @@ public class PdfViewer extends TiUIView implements OnErrorListener, LinkHandler 
 
     PDFView pdfView;
     int space = 20;
+    int pageNumber = 0;
     int layout_drawer_main = 0;
     int mode = MODE_URL;
     String currentUrl;
@@ -86,6 +87,14 @@ public class PdfViewer extends TiUIView implements OnErrorListener, LinkHandler 
         }
         if (arg0.equals("file")) {
             setFile(arg0);
+        }
+        if (arg0.equals("pageNumber")) {
+            this.pageNumber = TiConvert.toInt(arg2);
+            try {
+                pdfView.jumpTo(pageNumber, true);
+            } catch (Exception e) {
+                reload();
+            }
         }
     }
 
@@ -144,6 +153,9 @@ public class PdfViewer extends TiUIView implements OnErrorListener, LinkHandler 
             this.space = TiConvert.toInt(proxy.getProperty("spacing"));
             reload();
         }
+        if (props.containsKey("pageNumber")) {
+            this.pageNumber = TiConvert.toInt(proxy.getProperty("pageNumber"));
+        }
 
         if (props.containsKey("file")) {
             setFile(proxy.getProperty("file"));
@@ -192,6 +204,7 @@ public class PdfViewer extends TiUIView implements OnErrorListener, LinkHandler 
                         .swipeHorizontal(swipeHorizontal)
                         .nightMode(nightMode)
                         .linkHandler(this)
+                        .defaultPage(pageNumber)
                         .spacing(space)
                         .load();
                 if (nestedScrolling) {
@@ -207,6 +220,7 @@ public class PdfViewer extends TiUIView implements OnErrorListener, LinkHandler 
                         .onError(this)
                         .swipeHorizontal(swipeHorizontal)
                         .nightMode(nightMode)
+                        .defaultPage(pageNumber)
                         .spacing(space)
                         .linkHandler(this)
                         .load();
@@ -262,6 +276,7 @@ public class PdfViewer extends TiUIView implements OnErrorListener, LinkHandler 
                     .linkHandler(PdfViewer.this)
                     .swipeHorizontal(swipeHorizontal)
                     .nightMode(nightMode)
+                    .defaultPage(pageNumber)
                     .spacing(space)
                     .load();
             if (nestedScrolling) {


### PR DESCRIPTION
This pull request adds support for setting the initial page number displayed in the PDF viewer component. The feature is exposed as a new property and is integrated throughout the Android implementation to ensure the correct page is shown on load and when the property changes.

**New PDF Viewer Feature:**

* Added a `pageNumber` property to the PDF viewer, allowing users to specify the initial page to display.
* Integrated `pageNumber` into the Android implementation, including storing the value and updating the viewer when the property changes [[1]](diffhunk://#diff-55c78e00948ff6e993fb74b701910dead60cb4adf9a72793629d846e21b38d3aR41) [[2]](diffhunk://#diff-55c78e00948ff6e993fb74b701910dead60cb4adf9a72793629d846e21b38d3aR91-R98) [[3]](diffhunk://#diff-55c78e00948ff6e993fb74b701910dead60cb4adf9a72793629d846e21b38d3aR156-R158).